### PR TITLE
Add JSON.parse error handling for endpoint response.

### DIFF
--- a/server/components/services/openEPA.js
+++ b/server/components/services/openEPA.js
@@ -21,7 +21,13 @@ exports.getJSON = function(options, onResult)
     });
 
     res.on('end', function() {
-      var obj = JSON.parse(output);
+      var obj = {};
+      try {
+        obj = JSON.parse(output);
+      } catch (e) {
+        console.error('error parsing JSON: ' + e);
+        console.error('bad JSON: ' + output);
+      }
 
       onResult(res.statusCode, obj);
     });


### PR DESCRIPTION
Seems like the EPA.gov endpoint can return a non-error HTTP code w/o actually returning valid JSON. Error seems to be something like 'unexpected character <' - so I'm guessing it's returning HTML somehow. This just catches that so we can not terminate the process.
